### PR TITLE
Fix MJPEG port env variable check

### DIFF
--- a/server/utils/configHelper.js
+++ b/server/utils/configHelper.js
@@ -49,8 +49,8 @@ module.exports = {
   getMjpegStreamPort: () => {
     const port = getPortFromConfig(config, 'darknet_mjpeg_stream', 8090);
     if (
-      envDarknetJsonStreamPort
-      && parseAndTestIsNumber(envDarknetJsonStreamPort)
+      envDarknetMjpegStreamPort
+      && parseAndTestIsNumber(envDarknetMjpegStreamPort)
     ) {
       return parseInt(envDarknetMjpegStreamPort, 10);
     }


### PR DESCRIPTION
## Summary
- check `PORT_DARKNET_MJPEG_STREAM` when resolving MJPEG stream port

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847067e7d6883298941bb1bdfd1f20c